### PR TITLE
Periodically restart queue daemons & add more logging.

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -26,6 +26,11 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
+        // Queue a new "fetch" every 5 minutes. This will grab all profiles
+        // that were updated in the last 10 minutes (overlap intended).
         $schedule->command('mobilecommons:fetch')->everyFiveMinutes();
+
+        // Restart the queue daemons every hour to prevent memory issues.
+        $schedule->command('queue:restart')->hourly();
     }
 }

--- a/app/Jobs/LoadResultsFromMobileCommons.php
+++ b/app/Jobs/LoadResultsFromMobileCommons.php
@@ -60,6 +60,7 @@ class LoadResultsFromMobileCommons extends Job
 
         // Transform the returned profiles to arrays & send to Northstar
         foreach ($response->profiles->children() as $key => $profile) {
+            app('log')->debug('Queued Northstar job for '.$profile->attributes()->id.' from '.$this->start.'-'.$this->end.' page '.$this->page.'.');
             dispatch(new SendUserToNorthstar((string) $profile->asXML()));
         }
 


### PR DESCRIPTION
It seems like we're running into some issues with the queue listeners getting stuck once they've been running for a while. The `--daemon` option means the framework won't restart between jobs, so there's a potential that memory issues are slowing things down. I've added a hourly restart – not sure it'll fix things, but it seems like a reasonable idea anyways!

I also added some logging when we enqueue a new `SendUserToNorthstar` job so that we can hopefully track down where these duplicate jobs are coming from.

🌵 