### PR TITLE
Remove bulky markup from XML before queueing Northstar job.

### DIFF
--- a/app/Jobs/LoadResultsFromMobileCommons.php
+++ b/app/Jobs/LoadResultsFromMobileCommons.php
@@ -61,6 +61,10 @@ class LoadResultsFromMobileCommons extends Job
         // Transform the returned profiles to arrays & send to Northstar
         foreach ($response->profiles->children() as $key => $profile) {
             app('log')->debug('Queued Northstar job for '.$profile->attributes()->id.' from '.$this->start.'-'.$this->end.' page '.$this->page.'.');
+
+            // Remove extra markup from the XML so we don't have messages that won't "fit" in the queue.
+            unset($profile->address, $profile->custom_columns, $profile->location, $profile->clicks, $profile->integrations);
+
             dispatch(new SendUserToNorthstar((string) $profile->asXML()));
         }
 


### PR DESCRIPTION
#### Changes
This pull request updates the `LoadResultsFromMobileCommons` command to remove some unused fields from the XML document before queueing up a profile to be sent to Northstar. This should fix a problem where queued jobs were being rejected for being too large.

References #23.