### PR TITLE
Increase Mobile Commons timeout.

### DIFF
--- a/app/Services/MobileCommons.php
+++ b/app/Services/MobileCommons.php
@@ -31,7 +31,7 @@ class MobileCommons
         $this->client = new Client([
             'base_uri' => 'https://secure.mcommons.com/api/',
             'auth' => [$config['username'], $config['password']],
-            'timeout' => 15,
+            'timeout' => 45, // Mobile Commons can be sloooooooow.
         ]);
     }
 


### PR DESCRIPTION
Mobile Commons requests seem to timeout fairly frequently. Let's try to be more patient.

⏳